### PR TITLE
UVMS-3557: Deploy to nexus fix (no PR)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ branches:
   only:
   - master
   - dev
-  
+after_success:
+  -  test $TRAVIS_PULL_REQUEST == "false" && mvn deploy --settings travis-settings.xml -DskipTests=true -B

--- a/travis-settings.xml
+++ b/travis-settings.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>focus-releases</id>
+      <username>${env.NEXUS_USER_ID}</username>
+      <password>${env.NEXUS_PWD}</password>
+    </server>
+    <server>
+      <id>focus-snapshots</id>
+      <username>${env.NEXUS_USER_ID}</username>
+      <password>${env.NEXUS_PWD}</password>
+    </server>
+    <server>
+      <id>thirdparty</id>
+      <username>${env.NEXUS_USER_ID}</username>
+      <password>${env.NEXUS_PWD}</password>
+    </server>
+  </servers>   
+
+  <mirrors>
+    <mirror>
+      <!--This sends everything else to /public -->
+      <id>nexus</id>
+      <mirrorOf>*,!thirdparty</mirrorOf>
+      <url>https://nexus.focus.fish/nexus/repository/public/</url>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>nexus</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+    <profile>
+      <id>focus</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>thirdparty</id>
+          <name>FOCUS 3rd party</name>
+          <url>https://nexus.focus.fish/nexus/repository/thirdparty/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</settings>


### PR DESCRIPTION
I have opened for https on port 443 (->8083) to nexus and have included a default settings file (same as our own jenkins uses) which uses travis env user/pwd. Pull request shouldn't deploy if I made this correct.