### PR TITLE
Using mockito-core(2018) instead of mockito-all(2015)

### DIFF
--- a/uvms-pom-test-deps/pom.xml
+++ b/uvms-pom-test-deps/pom.xml
@@ -31,12 +31,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<exclusions>
-				<exclusion>
-					<artifactId>hamcrest-core</artifactId>
-					<groupId>org.hamcrest</groupId>
-				</exclusion>
-			</exclusions>
 			<version>${uvms-pom.test.deps.mockito.version}</version>
 		</dependency>
 		<dependency>

--- a/uvms-pom-test-deps/pom.xml
+++ b/uvms-pom-test-deps/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<uvms-pom.test.deps.junit.version>4.12</uvms-pom.test.deps.junit.version>
-		<uvms-pom.test.deps.mockito.version>1.10.19</uvms-pom.test.deps.mockito.version>
+		<uvms-pom.test.deps.mockito.version>2.22.0</uvms-pom.test.deps.mockito.version>
 		<uvms-pom.test.deps.easycoverage>2.3.1</uvms-pom.test.deps.easycoverage>
 		<uvms-pom.test.deps.contiperf>2.4.4</uvms-pom.test.deps.contiperf>
 		<uvms-pom.test.deps.powermock.version>1.6.6</uvms-pom.test.deps.powermock.version>		
@@ -30,7 +30,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
+			<artifactId>mockito-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>hamcrest-core</artifactId>
+					<groupId>org.hamcrest</groupId>
+				</exclusion>
+			</exclusions>
 			<version>${uvms-pom.test.deps.mockito.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
To exclude hamcrest from mockito we need to use mockito-core.